### PR TITLE
feat: new drives for `Walmart`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ _ **DriveOFF** is available on the extension stores, but you can also do the ins
 * [x] carrefour.fr
 * [ ] cora.fr
 * [x] intermarche.com
+* [x] wallmart.com (*product pages only*)
 * [ ] leclercdrive.fr

--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ _ **DriveOFF** is available on the extension stores, but you can also do the ins
 * [x] carrefour.fr
 * [ ] cora.fr
 * [x] intermarche.com
-* [x] wallmart.com (*product pages only*)
+* [x] walmart.com (*product pages only*)
 * [ ] leclercdrive.fr

--- a/js/drives/Wallmart.js
+++ b/js/drives/Wallmart.js
@@ -1,0 +1,35 @@
+drivesList.push(
+  class USWallmart extends Drive {
+    static get driveName() {
+      return "Wallmart";
+    }
+    static get domain() {
+      return /walmart\.com$/;
+    }
+    static get lang() {
+      return "en-US";
+    }
+    static get country() {
+      return "United States of America";
+    }
+
+    static get structure() {
+      return {
+        productView: {
+          base: ".buy-box-container",
+          name: "#main-title",
+          mainDescription: "#main-title",
+          description:
+            ".buy-box-container > div:nth-child(1) > section:nth-child(2)",
+          ean: () => {
+            try {
+              return JSON.parse(
+                document.querySelector("#__NEXT_DATA__").innerHTML
+              ).props.pageProps.initialData.data.product.upc;
+            } catch (error) {}
+          },
+        },
+      };
+    }
+  }
+);

--- a/js/drives/Walmart.js
+++ b/js/drives/Walmart.js
@@ -1,7 +1,7 @@
 drivesList.push(
-  class USWallmart extends Drive {
+  class USWalmart extends Drive {
     static get driveName() {
-      return "Wallmart";
+      return "Walmart";
     }
     static get domain() {
       return /walmart\.com$/;

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
         "/js/drives/Biocoop.js",
         "/js/drives/Carrefour.js",
         "/js/drives/Intermarche.js",
-        "/js/drives/Wallmart.js",
+        "/js/drives/Walmart.js",
         "/js/external/jbarcode.js",
         "/js/content_script.js"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,7 @@
         "/js/drives/Biocoop.js",
         "/js/drives/Carrefour.js",
         "/js/drives/Intermarche.js",
+        "/js/drives/Wallmart.js",
         "/js/external/jbarcode.js",
         "/js/content_script.js"
       ]


### PR DESCRIPTION
### What

Adding `Walmart` to the list of "drives".

### Screenshot


| Example | Before | After |
|:-:|:-:|:-:|
| https://www.walmart.com/ip/Duncan-Hines-Chewy-Fudge-Chocolate-Brownie-Mix-Family-Size-18-3-oz/10309845?athbdg=L1600 | ![image](https://github.com/openfoodfacts/DriveOFF/assets/1910927/f4e54b9f-3eaa-486f-804e-a0cc84cbdb52) | ![image](https://github.com/openfoodfacts/DriveOFF/assets/1910927/7bb38ac5-1e13-4df0-9223-00ecedf6883f) |
| https://www.walmart.com/ip/Nutella-Hazelnut-Spread-with-Cocoa-for-Breakfast-13-oz-Jar/10451273?athbdg=L1200&from=/search | ![image](https://github.com/openfoodfacts/DriveOFF/assets/1910927/9db02d4e-5a33-44d7-abfd-19e81ad4c5cc) | ![image](https://github.com/openfoodfacts/DriveOFF/assets/1910927/6937f64d-e981-4da5-aaa9-20c83195a6c8)) |
