### PR TITLE
feat: walmart

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _ **DriveOFF** is available on the extension stores, but you can also do the ins
 * [x] intermarche.com
 * [ ] leclercdrive.fr
 ### United States
+* [x] walmart.com (*product pages only*)
 ### Canada
 * [ ] Metro
 * [ ] SuperC

--- a/js/drives/Walmart.js
+++ b/js/drives/Walmart.js
@@ -1,0 +1,38 @@
+drivesList.push(
+  class USWalmart extends Drive {
+    static get driveName () {
+      return 'Walmart'
+    }
+
+    static get domain () {
+      return /walmart\.com$/
+    }
+
+    static get lang () {
+      return 'en-US'
+    }
+
+    static get country () {
+      return 'United States of America'
+    }
+
+    static get structure () {
+      return {
+        productView: {
+          base: '[data-testid="maincontent"]',
+          name: '#main-title',
+          mainDescription: '#ip-prod-desc-atf-div-1',
+          description:
+            '#ip-prod-desc-atf-div-1',
+          ean: () => {
+            try {
+              return JSON.parse(
+                document.querySelector('#__NEXT_DATA__').innerHTML
+              ).props.pageProps.initialData.data.product.upc
+            } catch (error) {}
+          }
+        }
+      }
+    }
+  }
+)

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
         "/js/drives/Intermarche.js",
         "/js/drives/Metro.js",
         "/js/drives/SuperC.js",
+        "/js/drives/Walmart.js",
         "/js/external/jbarcode.js",
         "/js/content_script.js"
       ]


### PR DESCRIPTION
### What

reviving https://github.com/openfoodfacts/DriveOFF/pull/9 (I lost access to my old github account), which adds the walmart.com drive

PS: A lot of products (ones not on the EU market?) aren't available in the openfood API

### Screenshot

| Product page | Before | After |
|-|-|-|
| https://www.walmart.com/ip/Nutella-Hazelnut-Spread-with-Cocoa-for-Breakfast-13-oz-Jar/10451273?athbdg=L1200&from=/search | <img width="1864" height="906" alt="image" src="https://github.com/user-attachments/assets/aa38651c-463d-426a-bf4a-abfe3e09a7ed" /> | <img width="1866" height="905" alt="image" src="https://github.com/user-attachments/assets/eb11f7de-c233-48d9-b07a-7185010d4b8a" /> |
| https://www.walmart.com/ip/Bonne-Maman-Hazelnut-Chocolate-Spread/2323852783 | <img width="1840" height="873" alt="image" src="https://github.com/user-attachments/assets/0a5ac726-f18f-49e4-8029-da9c3116fba6" /> | <img width="1902" height="895" alt="image" src="https://github.com/user-attachments/assets/aa951aa5-b8c5-41a3-a147-79f591f335b6" /> |


